### PR TITLE
rollback spring-cloud-kubernetes version to the one used on sb-2.3.10…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 
     <!-- Spring Ecosystem -->
     <spring-boot.version>2.4.9</spring-boot.version>
-    <spring-cloud-kubernetes.version>2.0.3</spring-cloud-kubernetes.version>
+    <spring-cloud-kubernetes.version>1.1.9.RELEASE</spring-cloud-kubernetes.version>
 
     <!-- Overriden from Spring Boot -->
     <hibernate.version>5.5.7.Final</hibernate.version>


### PR DESCRIPTION
…, 1.1.9.RELEASE