### PR TITLE
chore: update branch circleci testsuite to 2.5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           parent_version=$(mvn -s .circleci/settings.xml -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
 
           pushd /tmp
-          git clone --single-branch -b 2.4.x https://github.com/snowdrop/testsuite.git
+          git clone --single-branch -b 2.5.x https://github.com/snowdrop/testsuite.git
           cd testsuite
 
           echo "Setting testsuite parent version to ${parent_version}"
@@ -66,7 +66,7 @@ jobs:
           parent_version=$(mvn -s .circleci/settings.xml -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
 
           pushd /tmp
-          git clone --single-branch -b sb-2.4.x https://github.com/snowdrop/rest-http-example.git
+          git clone --single-branch -b sb-2.5.x https://github.com/snowdrop/rest-http-example.git
           cd rest-http-example
 
           echo "Setting rest-http-example parent version to ${parent_version}"

--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-dependencies</artifactId>
-    <version>2.4.9</version>
+    <version>2.5.7</version>
   </parent>
 
   <groupId>dev.snowdrop</groupId>
   <artifactId>snowdrop-dependencies</artifactId>
-  <version>2.4.9.SP1-SNAPSHOT</version>
+  <version>2.5.7-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Snowdrop Spring Boot Dependencies</name>
@@ -138,7 +138,7 @@
     <vertx-spring-boot.version>1.2.2</vertx-spring-boot.version>
 
     <!-- Spring Ecosystem -->
-    <spring-boot.version>2.4.9</spring-boot.version>
+    <spring-boot.version>2.5.7</spring-boot.version>
     <spring-cloud-kubernetes.version>2.0.3</spring-cloud-kubernetes.version>
 
     <!-- Overriden from Spring Boot -->


### PR DESCRIPTION
Update the circleci references to the 2.5.x branches.